### PR TITLE
関数の禁止をルールに追加

### DIFF
--- a/Tarosky/ruleset.xml
+++ b/Tarosky/ruleset.xml
@@ -92,7 +92,7 @@
 	<rule ref="Generic.PHP.ForbiddenFunctions">
 		<properties>
 			<property name="forbiddenFunctions" type="array">
-				<element key="print_r" value="echo"/>
+				<element key="print_r" value="null"/>
 				<element key="create_function" value="null"/>
 				<element key="var_dump" value="null"/>
 			</property>

--- a/Tarosky/ruleset.xml
+++ b/Tarosky/ruleset.xml
@@ -88,6 +88,17 @@
 	<!-- 問題があるかもしれない変数をあぶり出す。 -->
 	<rule ref="VariableAnalysis" />
 
+	<!-- var_dump を入れたままデプロイしない -->
+	<rule ref="Generic.PHP.ForbiddenFunctions">
+		<properties>
+			<property name="forbiddenFunctions" type="array">
+				<element key="print_r" value="echo"/>
+				<element key="create_function" value="null"/>
+				<element key="var_dump" value="null"/>
+			</property>
+		</properties>
+	</rule>
+	
 	<!-- プロジェクト内に、WordPressのPHPに対するクロスバージョンの互換性にイシューがあるかどうかをチェックする。-->
 	<rule ref="PHPCompatibilityWP"/>
 </ruleset>


### PR DESCRIPTION
`var_dump` や `print_r` などのデバッグコードを仕込んだままデプロイしないように、禁止関数に含める。 デバッグ機能などで使いたい時は明示的に `phpcs:ignore` する。